### PR TITLE
`=` sign missing in code example

### DIFF
--- a/src/shared/en/aws/guides-static-assets.md
+++ b/src/shared/en/aws/guides-static-assets.md
@@ -78,7 +78,7 @@ let arc = require('@architect/functions')
 function route(req, res) {
   let css = req._static('/main.css')
   let js = req._static('/main.js')
-  let html `
+  let html = `
   <!doctype html>
   <html>
   <head>


### PR DESCRIPTION
The example `let html ...` code is missing an equals sign. Without it, the example code isn't valid.

![screenshot 2018-06-26 at 11 34 40 pm](https://user-images.githubusercontent.com/250306/41951684-1f7c9f8a-799a-11e8-97f0-16a133c4ddca.png)
