### PR TITLE
📝 documenting the --delete static deploy flag

### DIFF
--- a/src/shared/en/aws/guides-static-assets.md
+++ b/src/shared/en/aws/guides-static-assets.md
@@ -60,6 +60,7 @@ And, of course, it would be wise to use both of these S3 buckets as origins for 
 
 > 🏌️‍♀️ Protip: `npx deploy static` will deploy the static assets _only_
 
+> ⛳️ Protip #2: `npx deploy [static] --delete` will remove files from the bucket that are no longer locally present
 
 ## Linking
 

--- a/src/shared/en/aws/reference-static.md
+++ b/src/shared/en/aws/reference-static.md
@@ -20,6 +20,12 @@ production main-bukkit
 
 > Note: S3 buckets are <b>global</b> to AWS so if at first you don't succeed, try picking another bucket name
 
-Locally, if the folder `/public` exists, whenever you run `npx deploy` the contents are synchronized to the `staging` bucket. If you set `ARC_DEPLOY=production` the contents of `/public` are deployed to the production bucket. 
+### Deployment
+
+Locally, if the folder `/public` exists, whenever you run `npx deploy` the contents are synchronized to the `staging` bucket. If you set `ARC_DEPLOY=production` the contents of `/public` are deployed to the production bucket.
+
+To _only_ deploy static assets from `/public` (and not function sources from `/src`), you can provide any of `--static`, `static` or `-s` flags, i.e. `npx deploy static`.
+
+To _delete_ remote static assets on the S3 bucket that do not exist locally, provide the optional `--delete` flag, i.e. `npx deploy static --delete`.
 
 ## Next: [Create dynamo tables with `@tables`](/reference/tables)


### PR DESCRIPTION
FYI @brianleroux 

I think similar to the discussion that was had in #50, this could probably use some more work and reasoning behind what kind of content to put in the CLI help docs vs. the `npx deploy` arc.codes guide vs. the Static Assets arc.codes guide.