### PR TITLE
Make GitHub link in arc docs point to arc docs

### DIFF
--- a/src/shared/render.js
+++ b/src/shared/render.js
@@ -65,7 +65,7 @@ function render(filename) {
       <footer class=footer></footer>
     </section>
     <script src=https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js></script>
-    <a href="https://github.com/arc-repos/architect" class="github-corner" aria-label="View source on Github">${github}</a>
+    <a href="https://github.com/arc-repos/arc.codes" class="github-corner" aria-label="View source on Github">${github}</a>
     <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
     <script>
       (function() {


### PR DESCRIPTION
The intention of the GitHub link is to get people to contribute to, or fix, the docs right? So the GitHub link should go the docs (in `arc.codes` repo), not to architect (in `architect` repo).