### PR TITLE
Add 'what next' to quickstart

### DIFF
--- a/src/shared/en/aws/_nav.md
+++ b/src/shared/en/aws/_nav.md
@@ -6,6 +6,7 @@
   - [Prerequisites](/quickstart)
   - [Installation](/quickstart/install)
   - [Project Layout](/quickstart/arc-project-layout)
+  - [What next?](/quickstart/what-next)
 - Guides
   - [HTTP Functions](/guides/http)
   - [Working Locally](/guides/offline)

--- a/src/shared/en/aws/_nav.md
+++ b/src/shared/en/aws/_nav.md
@@ -16,6 +16,7 @@
   - [Sessions](/guides/sessions)
   - [Middleware](/guides/middleware)
   - [Persist Data](/guides/data)
+  - [Background Tasks](/guides/background-tasks)
   - [Implement CORS](/guides/cors)
   - [Logging & Monitoring](/guides/logging)
   - [Assigning a Domain Name](/guides/custom-dns)

--- a/src/shared/en/aws/guides-background-tasks.md
+++ b/src/shared/en/aws/guides-background-tasks.md
@@ -1,5 +1,100 @@
 # Background Tasks
 
-> Use `.arc` defined `@events` and `@queues` to perform long running background tasks
+## Offloading items into smaller tasks for offline completion
 
-Coming soon!
+To ensure your user-facing lambas complete within limits, you can offload background tasks to other lambdas. `.arc` supports both `@events` and `@queues`
+
+SNS [`@events`](/reference/events) is a distributed publish-subscribe (pub/sub) system. Messages are immediately pushed to subscribers when they are sent by publishers. This is typically called a 'message bus'.
+
+SQS [`@queues`](/reference/queues) is distributed queuing system. Messages are NOT pushed to receivers. Receivers have to poll SQS to receive messages.
+
+In the example below, we'll make a pub/sub system using `@events` and `arc.events.publish`.
+
+Check the [example on GitHub](https://github.com/arc-repos/arc-example-events-pubsub) for a full version of the code described below.
+
+## Creating an SNS message bus
+
+In your `.arc` file, we're going to create a SNS message bus called `background-task`:
+
+```
+@events
+    background-task 
+```
+
+## Subscribing to the queue
+
+In `src/events/background-task/index.js` we'll subscribe to the queue:
+
+```javascript
+let arc = require('@architect/functions')
+let data = require('@architect/data')
+let series = require('run-series')
+
+// I copy paste this from MDN about once a week
+function random(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+function handler(record, callback) {
+  record.taskID = new Date(Date.now()).toISOString()
+  record.status = 'recieved'
+  // got a task!
+  series([
+    function save(callback) {
+      // save the record to the db
+      data.tasks.put(record, callback) 
+    },
+    function progress(callback) {
+      // after update the status to 'almost done' after 10-30 seconds
+      let timeout = random(3*1000, 10*1000)
+      setTimeout(function _delay() {
+        record.status = 'processing'
+        data.tasks.put(record, callback) 
+      }, timeout) 
+    },
+    function done(callback) {
+      // update the status to 'done' after an additional 10-30 seconds
+      let timeout = random(10*1000, 20*1000)
+      setTimeout(function _delay() {
+        record.status = 'complete'
+        data.tasks.put(record, callback) 
+      }, timeout) 
+    }
+  ], callback)
+}
+exports.handler = arc.events.subscribe(handler)
+
+```
+
+## Sending messages to the queue
+
+When we recieve a POST message from the client (in `/src/http/post-background`), we'll send it to the queue:
+
+```javascript
+let arc = require('@architect/functions')
+let url = arc.http.helpers.url
+
+exports.handler = async function http(req) {
+    await arc.events.publish({
+        name: 'background-task',
+        payload: {
+            background: req.body.background
+        }
+    })
+    return {
+        status: 302,
+        location: url('/')
+    }
+}
+
+```
+
+When a user POSTs to `/background` we'll respond immediately, but we'll also publish the payload into the `background-task` message bus, for processing by the subscriber in  `src/events/background-task`.
+
+---
+
+See [the events reference](/reference/events) for more details.
+
+## Next: [Logging & Monitoring](/guides/logging)

--- a/src/shared/en/aws/guides-data.md
+++ b/src/shared/en/aws/guides-data.md
@@ -795,5 +795,4 @@ exports.handler = arc.middleware(requireLogin, deleteNote)
 
 <hr>
 
-
-## Next: [Logging & Monitoring](/guides/logging)
+## Next: [Background Tasks](/guides/background-tasks)

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -120,40 +120,6 @@ You can combine multiple operations in a single route using the middleware API. 
 
 See [the middleware reference](/reference/middleware) for more details and an example.
 
-## Sessions (`arc.http.session`)
-
-HTTP functions can opt into session support using Architect's anonymous, signed, secure sessions:
-
-```javascript
-let arc = require('@architect/functions')
-
-exports.handler = async function http(req) {
-
-  // reads the session from DynamoDB
-  let state = await arc.http.session.read(req) 
-
-  // modify the state
-  state.foo = 'bar'
-
-  // save the session state to DynamoDB
-  let cookie = await arc.http.session.write(state)
-
-  // respond (and update the session cookie)
-  return {
-    cookie,
-    status: 302,
-    location: '/',
-  }
-}
-```
-
-All HTTP endpoints are sessions-enabled by default. 
-
-- Requests are tagged to a session via a signed cookie `_idx`
-- Session data expires after a week of inactivity
-
-> Sessions are stateless by default; learn how to [opt into database backed sessions with DynamoDB](/guides/sessions)
-
 ## URLs (`arc.http.helpers.url`)
 
 API Gateway generates long URLs that are hard to read, and extends the URL base path with either `staging` or `production` &mdash; this means a link intended to point at `/` should actually point at `/staging` or `/production`. (This pain point is eased if you set up a [custom domain name with DNS](/guides/custom-dns).)

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -2,9 +2,11 @@
 
 ## Create full-featured web applications composed of fast, tiny HTTP functions
 
-Here's well go from a basic 'hello world' app to a bigger app with signups and logins. 
+Here we'll start from a basic 'hello world' app and then build a bigger app with signups and logins. 
 
-> `.arc` abstracts API Gateway configuration and provisioning, while `@architect/functions` (optionally) adds a very light but powerful API shim to Lambda for working with HTTP
+We'll do this with AWS Lambdas - small functions that trigger when their URL is hit. You can think of lambdas as the equivaleny of 'routes' in traditional web apps. 
+
+AWS Lambdas are accessed via API Gateway, but `.arc` abstracts API Gateway and Lambda configuration and provisioning. Additionally, `@architect/functions` (optionally) adds useful tools for working with HTTP.
 
 Given the following example `.arc` file:
 
@@ -42,7 +44,7 @@ Every HTTP handler receives a plain JavaScript object `request` as a first param
 - <b>`query`</b> - `Object`, any query params, if present
 - <b>`headers`</b> - `Object`, contains all client request headers 
 
-To send a response, HTTP functions support the following params as a plain JavaScript `Object`:
+To send a response, HTTP functions return a plain JavaScript `Object` with the following params:
 
 - <b>`status`</b> (or <b>`code`</b>) - `number`, sets the HTTP status code
 - <b>`type`</b> - `string`, sets the `Content-Type` response header

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -142,27 +142,6 @@ exports.handler = async function http(req) {
 > 👋 After DNS propagates you can remove calls to `arc.http.helpers.url` from your code. Learn how to [assign a domain name](/guides/custom-dns) by setting up DNS.
 
 
-## Static (`arc.http.helpers.static`)
-
-Architect projects can be set up with `staging` and `production` S3 buckets for file syncing from the [`public` folder](/guides/static-assets).
-
-Each of these has its own URL – not to mention the local path in `sandbox`, which can mean trouble when trying to load the right version of a static asset.
-
-The `arc.http.helpers.static` helper resolves URL paths for your static assets, so you're requesting the right file from every environment.
-
-Here's an example of `static` usage:
-
-```javascript
-let arc = require('@architect/functions')
-let static = arc.http.helpers.static
-
-exports.handler = async function http(req) {
-  return {
-    type: 'text/html',
-    body: `Hey, it's an image! <img src="${static('/img/rainbows.gif')}">`
-  }
-}
-```
 
 
 ---

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -109,16 +109,7 @@ The following API is supported in `@architect/functions`:
 
 > 📈 `@architect/functions` also has helpers for implementing pub/sub patterns by invoking SNS and SQS Lambda functions, defined by [`@events`](/reference/events) and [`@queues`](/reference/queues), respectively.
 
-## Middleware (`arc.middleware`)
 
-You can combine multiple operations in a single route using the middleware API. This is similar to middleware processing in other node frameworks, but uses the same style as regular Arc routes. Just run `arc.middleware()` specifying each middleware item as arguments. Requests will be run through each middleware item in the order they're given to `arc.middleware()` with the following rules:
-
-- A middleware item is a function that takes a [request](/guides/http)
-- If the middleware item doesn't return anything, the [request](/guides/http) will be passed to the next middleware item in the queue
-- If the middleware returns a modified [request](/guides/http), the modified request will be passed to the next middleware item
-- If the middleware item returns a [response](/guides/http), this will end processing and send the response back. 
-
-See [the middleware reference](/reference/middleware) for more details and an example.
 
 ## URLs (`arc.http.helpers.url`)
 

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -2,6 +2,8 @@
 
 ## Create full-featured web applications composed of fast, tiny HTTP functions
 
+Here's well go from a basic 'hello world' app to a bigger app with signups and logins. 
+
 > `.arc` abstracts API Gateway configuration and provisioning, while `@architect/functions` (optionally) adds a very light but powerful API shim to Lambda for working with HTTP
 
 Given the following example `.arc` file:

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -88,7 +88,7 @@ module.exports = async function http(req) {
 
 # Helpers for your functions
 
-HTTP functions come with `@architect/functions` and `@architect/data` installed. These have convenient helpers for working with the unique characteristics of API Gateway and DynamoDB, respectively.
+HTTP functions come with `@architect/functions` and `@architect/data` installed. These have convenient helpers for working with API Gateway and DynamoDB, respectively.
 
 ```javascript
 // opt into architect functions and data conveniences
@@ -96,21 +96,13 @@ let arc = require('@architect/functions')
 let data = require('@architect/data')
 ```
 
-Below we'll focus on `@architect/functions`; to learn more about the [`@architect/data` API, head here](/reference/data).
-
-The following API is supported in `@architect/functions`:
+In the example below we'll use some of the helpers from  `@architect/functions`:
  
-- <b>[`arc.middleware`](#middleware-arc-middleware-)</b> - middleware API, allowing requests to be filtered through multiple steps before sending a response.
-- <b>[`arc.http.session.read`](#sessions-arc-http-session-)</b> - read the session using the request cookie
-- <b>[`arc.http.session.write`](#sessions-arc-http-session-)</b> - write the session returning a cookie string
-- <b>[`arc.http.helpers.url`](#urls-arc-http-helpers-url-)</b> - transform `/` into the appropriate `staging` and `production` API Gateway paths
-- <b>[`arc.http.helpers.static`](#static-arc-http-helpers-static-)</b> - accepts a path part and returns path to `localhost:3333` or `staging` and `production` S3 buckets
+- <b>[`arc.middleware`](/guides/middleware)</b> - middleware API, allowing requests to be filtered through multiple steps before sending a response.
+- <b>[`arc.http.session`](/guides/sessions)</b> - read the session using the request cookie, write the session returning a cookie string
+- <b>[`arc.http.helpers.url`](/guides/urls)</b> - transform `/` into the appropriate `staging` and `production` API Gateway paths
+- <b>[`arc.http.helpers.static`](/guides/static)</b> - accepts a path part and returns path to `localhost:3333` or `staging` and `production` S3 buckets
 - <b>`arc.http.helpers.verify`</b> - verify a `csrf` token
-
-> 📈 `@architect/functions` also has helpers for implementing pub/sub patterns by invoking SNS and SQS Lambda functions, defined by [`@events`](/reference/events) and [`@queues`](/reference/queues), respectively.
-
-
-
 
 ---
 

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -6,7 +6,7 @@ Here we'll start from a basic 'hello world' app and then build a bigger app with
 
 We'll do this with AWS Lambdas - small functions that trigger when their URL is hit. You can think of lambdas as the equivaleny of 'routes' in traditional web apps. 
 
-AWS Lambdas are accessed via API Gateway, but `.arc` abstracts API Gateway and Lambda configuration and provisioning. Additionally, `@architect/functions` (optionally) adds useful tools for working with HTTP.
+AWS Lambdas are accessed via API Gateway, but `.arc` abstracts API Gateway and Lambda configuration and provisioning. 
 
 Given the following example `.arc` file:
 
@@ -18,7 +18,7 @@ testapp
 get /
 ```
 
-By default, HTTP functions are dependency free with a minimal, but very powerful, low level API. 
+When a user visits `/`, the following HTTP function in `src/http/get-index/index.js` will run: 
 
 ```javascript
 exports.handler = async function http(request) {
@@ -26,16 +26,16 @@ exports.handler = async function http(request) {
     status: 201,
     type: 'text/html; charset=utf8',
     body: `
-    <!doctype html>
-    <html>
-      <body>hello world</body>
-    </html>
+      <!doctype html>
+      <html>
+        <body>hello world</body>
+      </html>
    `
   }
 }
 ```
 
-Every HTTP handler receives a plain JavaScript object `request` as a first parameter with the following keys:
+By default, HTTP functions are dependency free with a minimal, but very powerful, low level API: every HTTP function receives a plain JavaScript `Object` called `request` as a first parameter. `request` has the following keys:
 
 - <b>`body`</b> - `Object`, request body, including an `Object` containing any `application/x-www-form-urlencoded` form variables
 - <b>`path`</b> - `string`, absolute path of the request
@@ -44,7 +44,7 @@ Every HTTP handler receives a plain JavaScript object `request` as a first param
 - <b>`query`</b> - `Object`, any query params, if present
 - <b>`headers`</b> - `Object`, contains all client request headers 
 
-To send a response, HTTP functions return a plain JavaScript `Object` with the following params:
+To send a response, HTTP functions return a plain JavaScript  with the following params:
 
 - <b>`status`</b> (or <b>`code`</b>) - `number`, sets the HTTP status code
 - <b>`type`</b> - `string`, sets the `Content-Type` response header
@@ -53,6 +53,7 @@ To send a response, HTTP functions return a plain JavaScript `Object` with the f
 - <b>`cookie`</b> - `string`, sets the `Set-Cookie` response header
 - <b>`cors`</b> - `boolean`, sets the various CORS headers
 
+`@architect/functions` (optionally) adds additional useful tools for working with HTTP, including middlewere, sessions, and more.
 
 ## Code sharing
 
@@ -64,7 +65,7 @@ module.exports = function layout(html) {
   return `
     <!doctype html>
     <html>
-    <body><h1>Layout!</h1>${html}</body>
+      <body><h1>Layout!</h1>${html}</body>
     </html>
   `
 }

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -86,7 +86,7 @@ module.exports = async function http(req) {
 ---
 
 
-# Helpers for your functions
+## Helpers for your functions
 
 HTTP functions come with `@architect/functions` and `@architect/data` installed. These have convenient helpers for working with API Gateway and DynamoDB, respectively.
 

--- a/src/shared/en/aws/guides-http.md
+++ b/src/shared/en/aws/guides-http.md
@@ -111,38 +111,6 @@ The following API is supported in `@architect/functions`:
 
 
 
-## URLs (`arc.http.helpers.url`)
-
-API Gateway generates long URLs that are hard to read, and extends the URL base path with either `staging` or `production` &mdash; this means a link intended to point at `/` should actually point at `/staging` or `/production`. (This pain point is eased if you set up a [custom domain name with DNS](/guides/custom-dns).)
-
-`@architect/functions` also bundles a helper function `arc.http.helpers.url` for resolving URL paths that haven't yet been configured with DNS. This is helpful for early prototyping.
-
-Here's an example index page that demonstrates `url` usage:
-
-```javascript
-let arc = require('@architect/functions')
-let url = arc.http.helpers.url
-
-exports.handler = async function http(req) {
-  if (req.session.isLoggedIn) {
-    return {
-      type: 'text/html',
-      body: `<a href=${url('/logout')}>logout</a>`
-    }
-  }
-  else {
-    return {
-      status: 302,
-      location: url('/login')
-    } 
-  }
-}
-```
-
-> 👋 After DNS propagates you can remove calls to `arc.http.helpers.url` from your code. Learn how to [assign a domain name](/guides/custom-dns) by setting up DNS.
-
-
-
 
 ---
 

--- a/src/shared/en/aws/guides-middleware.md
+++ b/src/shared/en/aws/guides-middleware.md
@@ -1,6 +1,6 @@
-# Middleware
+# Middleware (`arc.middleware`)
 
-You can combine multiple operations in a single route using the middleware API. This is similar to middleware processing in other node frameworks, but uses [the same style as regular Arc routes](/guides/http). Just run `arc.middleware()` specifying each middleware item as arguments. Requests will be run through each middleware item in the order they're given to `arc.middleware()` with the following rules:
+You can combine multiple operations in a single route using the middleware API. This is similar to middleware processing in other node frameworks, but uses [the same style as regular Arc routes](/guides/http). Just run `arc.middleware()` specifying each middleware item as arguments. `arc.middleware()` outputs a lambda, combining the middlewares given as arguments. Requests will be run through each middleware item in the order they're given to `arc.middleware()` with the following rules:
 
 - A middleware item is a function that takes a [request](/guides/http)
 - If the middleware item doesn't return anything, the request will be passed to the next middleware item in the queue
@@ -66,5 +66,7 @@ The middleware API works well with [the `shared` folder](/guides/sharing-common-
 
 - Authentication
 - Adding context to requests
+
+See [the middleware reference](/reference/middleware) for more details.
 
 ## Next: [Work Locally](/guides/offline)

--- a/src/shared/en/aws/guides-sessions.md
+++ b/src/shared/en/aws/guides-sessions.md
@@ -1,8 +1,11 @@
-# Sessions
+# Sessions (`arc.http.session`)
 
-> All `@http` defined routes are session capable via `@architect/functions`
+All `@http` defined routes are session capable via `@architect/functions`
 
-By default all routes in an Architect apps are enabled with a stateless, signed, encrypted, httpOnly cookie. This allows you to write fully stateful applications despite Lambda functions being completely stateless. 
+- Requests are tagged to a session via a stateless, signed, encrypted, httpOnly cookie `_idx`
+- Session data expires after a week of inactivity
+
+This allows you to write fully stateful applications despite Lambda functions being completely stateless. 
 
 Read the session:
 
@@ -10,6 +13,7 @@ Read the session:
 let arc = require('@architect/functions')
 
 exports.handler = async function http(req) {
+  // reads the session from DynamoDB
   let session = await arc.http.session.read(req)
   return {
     type: 'text/html; charset=utf8',
@@ -24,11 +28,16 @@ Write the session:
 let arc = require('@architect/functions')
 
 exports.handler = async function http(req) {
+  // reads the session from DynamoDB
   let session = await arc.http.session.read(req)
+
+  // modify the state
   session.count = (session.count || 0) + 1
+  // save the session state to DynamoDB
   let cookie = await arc.http.session.write(session)
   let status = 302
   let location = '/'
+  // respond (and update the session cookie)
   return {cookie, status, location}
 }
 ```
@@ -76,6 +85,8 @@ This will sync all production lambdas to use the DynamoDB table while testing an
 - Authentication
 - Error messages
 - Shopping carts
+
+See [the sessions reference](/reference/sessions) for more details.
 
 <hr>
 

--- a/src/shared/en/aws/guides-static-assets.md
+++ b/src/shared/en/aws/guides-static-assets.md
@@ -1,11 +1,14 @@
-# Static Assets
+# Static (`arc.http.helpers.static`)
 
 ## Automatically build and deploy your static assets
 
+Architect projects support a `public` directory in the root of your project for static assets. The `public` directory typically includes static assets such as images, styles, and scripts required in your front-end workflows. 
 
-Static assets are crucial infrastructure for building ambitious web apps. While `.arc` does not have any opinion about how you should achieve that part, it can provision and automatically deploy to isolated S3 buckets for your app's `staging` and `production` environments.
+Anything in  `public` directory is available at `http://localhost:3333/_static/` when running in the sandbox. 
 
-Every `.arc` project is supports `./public` directory in the root of your project. The `public` directory provides a seamless way to work with static assets such as images, styles, and scripts required in your front-end workflows. Anything in that directory is available at `http://localhost:3333/_static/` when running in the sandbox and at `https://yourapi.com/_static` once deployed to API Gateway.
+For `production` and `staging` environments, Architect can have `staging` and `production` S3 buckets for file syncing from the `public` folder - they'll be avaiable at at `https://yourapi.com/_static` once deployed.
+
+The `arc.http.helpers.static` helper resolves URL paths for your static assets, so you're requesting the right file from every environment.
 
 ## Provisioning
 
@@ -22,7 +25,7 @@ production my-unique-bucket
 
 Running `npx create` will generate `staging` and `production` S3 buckets.
 
-> ⚠️ Warning: S3 buckets are _globally_ unique to all of AWS so you may have to try a few names
+> ⚠️ Warning: S3 buckets are _globally_ unique to all of AWS so you may have to try a few names.
 
 
 ## Working Locally with `public`
@@ -88,25 +91,27 @@ let arc = require('@architect/functions')
 let static = arc.http.helpers.static
 
 exports.handler = async function http(req) {
-  let css = static('/main.css')
-  let js = static('/main.js')
   let body = `
-  <!doctype html>
-  <html>
-    <head>
-      <title>This is fun!</title>
-      <link rel=stylesheet type=text/css href=${css}>
-    </head>
-    <body>Hello ƛ</body>
-    <script src=${js}></script>
-  </html>
+    <!doctype html>
+    <html>
+      <head>
+        <title>This is fun!</title>
+        <link rel=stylesheet type=text/css href=${static('/main.css')}>
+      </head>
+      <body>Hello ƛ</body>
+      <script src=${static('/main.js')}></script>
+    </html>
   `
   return {
     type: 'text/html',
     body
   }
 }
+
+
 ```
+
+See [the static reference](/reference/static) for more details.
 
 <hr>
 

--- a/src/shared/en/aws/guides-urls.md
+++ b/src/shared/en/aws/guides-urls.md
@@ -1,0 +1,35 @@
+# URLs (`arc.http.helpers.url`)
+
+## Get the correct URLs across sandbox, staging and production
+
+API Gateway generates long URLs that are hard to read, and extends the URL base path with either `staging` or `production` &mdash; this means a link intended to point at `/` should actually point at `/staging` or `/production`. 
+
+> 👉🏽 Note: you don't need to worry about URL differences if you set up a [custom domain name with DNS](/guides/custom-dns)
+
+If you haven't set up DNS yet, `@architect/functions` bundles a helper function `arc.http.helpers.url` for resolving URL paths. This is helpful for early prototyping.
+
+Here's an example index page that demonstrates `url` usage:
+
+```javascript
+let arc = require('@architect/functions')
+let url = arc.http.helpers.url
+
+exports.handler = async function http(req) {
+  if (req.session.isLoggedIn) {
+    return {
+      type: 'text/html',
+      body: `<a href=${url('/logout')}>logout</a>`
+    }
+  }
+  else {
+    return {
+      status: 302,
+      location: url('/login')
+    } 
+  }
+}
+```
+
+> 👋 After DNS propagates you can remove calls to `arc.http.helpers.url` from your code. Learn how to [assign a domain name](/guides/custom-dns) by setting up DNS.
+
+

--- a/src/shared/en/aws/quickstart-arc-project-layout.md
+++ b/src/shared/en/aws/quickstart-arc-project-layout.md
@@ -89,4 +89,4 @@ Happy with staging? Ship a release to production by running `npx deploy producti
 
 Time to celebrate! ✨
 
-## Next: [Learn how to work with HTTP functions](/guides/http)
+## Next: [What next?](/quickstart/what-next)

--- a/src/shared/en/aws/quickstart-what-next.md
+++ b/src/shared/en/aws/quickstart-what-next.md
@@ -1,0 +1,15 @@
+# What next?
+
+Now that you're familiar with the basics, it's time to build more complex apps. The guides below come with examples on [Architect GitHub](https://github.com/arc-repos):
+
+ - Add [lambdas](/guides/http) - these will be the basic routes of your app. Follow this to expand on the Hello World app we just made!
+
+ - Use DynamoDB [data](/guides/data) to store and retrieve items from DynamoDB.
+
+ - Use [sessions](/guides/sessions) - Architect comes with inbuilt, fast sessions thanks to DynamoDB.
+
+ - Use [middleware](/guides/middleware) - middleware allows you to combine routing logic, and is useful for checking if a user is logged in, adding extra information to the request, and similar tasks tasks.
+
+ - [Share code](/guides/sharing-common-code) between your lambdas
+
+ - Add [background tasks](/guides/background-tasks) - useful for splitting up larger tasks into smaller ones


### PR DESCRIPTION
 - Add 'what next' to quickstart linking to the various tutorials
 - Add 'background tasks' guide
 - Move/consolidate the docs in `http` for `sessions`, `middleware` etc into their respective guides, making `http` a lot smaller and using links to the various guides.

Fixes #77 