### PR TITLE
Avoid overloading 'context'

### DIFF
--- a/src/shared/en/aws/guides-middleware.md
+++ b/src/shared/en/aws/guides-middleware.md
@@ -65,7 +65,7 @@ The middleware API works well with [the `shared` folder](/guides/sharing-common-
 ## Common Session Use Cases
 
 - Authentication
-- Adding context to requests
+- Adding additional info to requests
 
 See [the middleware reference](/reference/middleware) for more details.
 


### PR DESCRIPTION
Since 'context' has a specific meaning for lambda